### PR TITLE
build(deps): bump the nix group with 2 updates

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -99,11 +99,11 @@
         "spectrum": "spectrum"
       },
       "locked": {
-        "lastModified": 1778669912,
-        "narHash": "sha256-WT2iimtOBZM/6AcZeBoJU2EgUSaywtlItsEgNkZBda0=",
+        "lastModified": 1779043402,
+        "narHash": "sha256-1dH6yiwEck1n3oz5TDUV5TGbwNqu46eNTVHbhFO2U5k=",
         "owner": "microvm-nix",
         "repo": "microvm.nix",
-        "rev": "a7a7009064cec75d9da652c6723412ce27b9bc44",
+        "rev": "77024c22f4ddf509137fc732094888d1ffe631e2",
         "type": "github"
       },
       "original": {
@@ -203,11 +203,11 @@
     "spectrum": {
       "flake": false,
       "locked": {
-        "lastModified": 1772189877,
-        "narHash": "sha256-i1p90Rgssb//aNiTDFq46ZG/fk3LmyRLChtp/9lddyA=",
+        "lastModified": 1778940603,
+        "narHash": "sha256-voSM8dZNlaOWN3kbYFky+FNY6fFQOEw0xF+ZMpZKkCQ=",
         "ref": "refs/heads/main",
-        "rev": "fe39e122d898f66e89ffa17d4f4209989ccb5358",
-        "revCount": 1255,
+        "rev": "367dd227f539267eae2b62770b4c17b88ac8c1f1",
+        "revCount": 1265,
         "type": "git",
         "url": "https://spectrum-os.org/git/spectrum"
       },
@@ -299,11 +299,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778882590,
-        "narHash": "sha256-RpOTonvtj16N4Os15zengbtzHmQZ3kMAQMi2iMJrO3w=",
+        "lastModified": 1779053704,
+        "narHash": "sha256-6ZOdy30spq4y7EsrCm/Bl9kZm2eCN2ief3Kw2Qwo82w=",
         "owner": "BirdeeHub",
         "repo": "nix-wrapper-modules",
-        "rev": "950d02a943df44ebc250c724de89dee95761789a",
+        "rev": "616a22a9dcb53dfa389712065bc4f0d3b23421a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps the nix group with 2 updates: [microvm](https://github.com/microvm-nix/microvm.nix) and [wrappers](https://github.com/BirdeeHub/nix-wrapper-modules).


Updates `microvm` from `a7a7009` to `77024c2`
- [Commits](https://github.com/microvm-nix/microvm.nix/compare/a7a7009064cec75d9da652c6723412ce27b9bc44...77024c22f4ddf509137fc732094888d1ffe631e2)

Updates `wrappers` from `950d02a` to `616a22a`
- [Commits](https://github.com/BirdeeHub/nix-wrapper-modules/compare/950d02a943df44ebc250c724de89dee95761789a...616a22a9dcb53dfa389712065bc4f0d3b23421a3)

---
updated-dependencies:
- dependency-name: microvm
  dependency-version: 77024c22f4ddf509137fc732094888d1ffe631e2
  dependency-type: direct:production
  dependency-group: nix
- dependency-name: wrappers
  dependency-version: 616a22a9dcb53dfa389712065bc4f0d3b23421a3
  dependency-type: direct:production
  dependency-group: nix
...

Signed-off-by: dependabot[bot] <support@github.com>