### PR TITLE
fix(ci): make dependabot schedules deterministic

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
         patterns: ["*"]
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "05:30"
+      timezone: "Asia/Kolkata"
     cooldown:
       default-days: 7
   - package-ecosystem: "nix" # zizmor: ignore[dependabot-cooldown]
@@ -22,6 +25,6 @@ updates:
       nix:
         patterns: ["*"]
     schedule:
-      interval: "daily"
-      time: "05:00"
+      interval: "cron"
+      cronjob: "0 5 * * *"
       timezone: "Asia/Kolkata"


### PR DESCRIPTION
- GitHub Actions updates now run weekly on Monday at 05:30 Asia/Kolkata.
- Nix updates now use a cron schedule, 0 5 * * *, so they run every day at 05:00
Asia/Kolkata instead of Dependabot’s daily, which GitHub documents as weekdays
only.

Assisted-by: OpenAI Codex:gpt-5.5
