### PR TITLE
tack: update

### DIFF
--- a/.tack/pins.lock.json
+++ b/.tack/pins.lock.json
@@ -55,9 +55,9 @@
     "type": "github",
     "owner": "microvm-nix",
     "repo": "microvm.nix",
-    "rev": "0784796ba5c4ba17c58fce3c2c0cbccc60d22e84",
-    "narHash": "sha256-2aNPMX+33DdK/tVXMabpVNRzFJ5m2IgYaaw8LL0Tb9Q=",
-    "lastModified": 1784395873
+    "rev": "fa5340ac684cdce8a22b6d4a0bcebb0cc999275e",
+    "narHash": "sha256-xgfS6slV7J3baMooNN1UuBi51RIgg9y0DbCxfSA0668=",
+    "lastModified": 1784666190
   },
   "nix-devshells": {
     "type": "git",

--- a/modules/niri/default.nix
+++ b/modules/niri/default.nix
@@ -27,6 +27,7 @@ in
         ];
         settings = {
           spawn-at-startup = [
+            [ "ckb-next" ]
             [
               "wl-clip-persist"
               "--clipboard"
@@ -44,7 +45,7 @@ in
             };
             mouse = {
               accel-profile = "flat";
-              accel-speed = -0.8;
+              accel-speed = -0.6;
             };
           };
           layout = {


### PR DESCRIPTION
microvm: 0784796 -> fa5340a (ahead)
         3 ahead
         fa5340a    Merge pull request #563 from luochen1990/feat/per-share-extraArgs
         b680c7c    virtiofs: assert posixAcl vs translate-uid/gid exclusivity
         3eadfbb    virtiofs: add per-share posixAcl and extraArgs
         0784796    Merge pull request #558 from LapineLunaire/cloud-hypervisor-cpus-extraargs
