### PR TITLE
tack: update

### DIFF
--- a/.tack/pins.lock.json
+++ b/.tack/pins.lock.json
@@ -55,9 +55,9 @@
     "type": "github",
     "owner": "microvm-nix",
     "repo": "microvm.nix",
-    "rev": "06544a68599a0e0721760af442000204e57e3937",
-    "narHash": "sha256-d/AR1r5guAk52ZWM0sAd3O8Fd2jQbyGwxU+e6flTiUk=",
-    "lastModified": 1785510331
+    "rev": "e615e23267bf10d483fb44f759d4e61c354cc0f4",
+    "narHash": "sha256-H/0YgQ+3BtNbdeSVuqjU7ElneBzPPuIKcuWOi0ZUktQ=",
+    "lastModified": 1785843289
   },
   "nix-devshells": {
     "type": "git",
@@ -77,9 +77,9 @@
   },
   "nixpkgs": {
     "type": "tarball",
-    "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1046609.643809054d65/nixexprs.tar.zst",
-    "rev": "643809054d65fdd466a63e3155b8c498cb483c04",
-    "narHash": "sha256-1+YGJM7PLfvTsbUxDHKj0NcuEXYFHfZBDuajujCcVmY="
+    "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1047536.e72e4f299401/nixexprs.tar.zst",
+    "rev": "e72e4f299401a3689d4b3d5fc6496b11db7064eb",
+    "narHash": "sha256-VFlH/0nM6kkWQox9IaTqx2eCT3pmkr8bB7iVZ1bkaLs="
   },
   "rust-analyzer": {
     "type": "github",
@@ -109,9 +109,9 @@
     "type": "github",
     "owner": "manic-systems",
     "repo": "tack",
-    "rev": "eeeeb38f444c047642eaa7f81946df6e17b77ce5",
-    "narHash": "sha256-mrzOe9u1EdkVRc31rVhiNeSHXSfnjsYzWMCNFGOS51E=",
-    "lastModified": 1785804627
+    "rev": "62a67545adaf01b48d01ee73c0d16353ca68432e",
+    "narHash": "sha256-rTiX4SZ9Sjei3WzsW25nDTZweMRzA7ZunspkhDXkZfY=",
+    "lastModified": 1785878583
   },
   "treefmt-nix": {
     "type": "github",

--- a/modules/noctalia/default.nix
+++ b/modules/noctalia/default.nix
@@ -17,6 +17,9 @@ in
       imports = [ wlib.modules.default ];
       env.NOCTALIA_CONFIG_HOME = "${placeholder "out"}/config";
       package = pkgs.noctalia;
+      runtimePkgs = [
+        pkgs.ddcutil
+      ];
       constructFiles.generatedConfig = {
         content = lib.readFile ./noctalia-config.toml;
         relPath = "config/config.toml";
@@ -30,6 +33,7 @@ in
       {
         options.noctaliaPackage = lib.mkPackageOption pkgs "noctalia" { };
         config = {
+
           noctaliaPackage = lib.mkDefault (wrappers.noctalia-v5.wrap { inherit pkgs; });
           extraSettings = [
             {
@@ -112,7 +116,7 @@ in
     {
       environment.systemPackages = [
         pkgs.wtype
-        pkgs.noctalia
+        (wrappers.noctalia-v5.wrap { inherit pkgs; })
       ];
     };
 }

--- a/modules/noctalia/noctalia-config.toml
+++ b/modules/noctalia/noctalia-config.toml
@@ -3,11 +3,12 @@ ui_scale = 1.1500000096857548
 
 [bar.default]
 background_opacity = 0.7499999832361937
-padding = 20
 position = "right"
-scale = 1.250000011175871
+scale = 1.400000013411045
 smart_auto_hide = true
-thickness = 45
+
+[brightness]
+enable_ddcutil = true
 
 [lockscreen_widgets]
 enabled = false
@@ -56,6 +57,7 @@ source = "wallpaper"
 [theme.templates]
 builtin_ids = [
   "alacritty",
+  "btop",
   "gtk3",
   "gtk4",
   "ghostty",
@@ -65,6 +67,7 @@ builtin_ids = [
   "niri",
   "qt",
 ]
+community_ids = ["zen-browser", "steam"]
 
 [wallpaper]
 directory = "/home/ssmvabaa/wallpapers"

--- a/modules/noctalia/wwk.nix
+++ b/modules/noctalia/wwk.nix
@@ -7,17 +7,17 @@
     {
       key = "n";
       desc = "Toggle Notifications";
-      cmd = "noctalia-shell ipc call notifications toggleHistory";
+      cmd = "noctalia msg panel-toggle control-center notifications";
     }
     {
       key = "c";
       desc = "Toggle Calendar";
-      cmd = "noctalia-shell ipc call calendar toggle";
+      cmd = "noctalia msg panel-toggle  control-center calendar";
     }
     {
       key = "v";
       desc = "Toggle Clipboard";
-      cmd = "noctalia-shell ipc call launcher clipboard";
+      cmd = "noctalia msg panel-toggle clipboard";
     }
   ];
 }


### PR DESCRIPTION
microvm: 06544a6 -> e615e23 (ahead)
         3 ahead
         e615e23    build(deps): bump spectrum from `24c4346` to `a7762d6` (#576)
         4963012    Merge pull request #577 from microvm-nix/dependabot/nix/nixpkgs-1559d3d
         e834bd5    build(deps): bump nixpkgs from `241313f` to `1559d3d`
         06544a6    Merge pull request #572 from mksafavi/vsock-missing
nixpkgs: nixos-26.11pre10 -> nixos-26.11pre10
tack: eeeeb38 -> 62a6754 (ahead)
      1 ahead
      62a6754    update: add --exclude argument
      eeeeb38    .tack: move variable to lower scope
